### PR TITLE
Implement Private (Direct) Messaging

### DIFF
--- a/SCRIPTS/ws_client.py
+++ b/SCRIPTS/ws_client.py
@@ -13,11 +13,6 @@ def on_close(ws, close_status_code, close_msg):
 
 def on_open(ws):
     print("WebSocket connection opened")
-    msg = {
-        "type": "message",
-        "content": "Hello, room!"
-    }
-    ws.send(json.dumps(msg))
 
 if __name__ == "__main__":
     room_id = input("Enter room ID: ").strip()
@@ -45,7 +40,20 @@ if __name__ == "__main__":
             msg = input("Type message (or 'exit' to quit): ")
             if msg.lower() == "exit":
                 break
-            ws.send(json.dumps({"type": "message", "content": msg}))
+            direct = input("Send as direct message? (y/n): ").strip().lower()
+            if direct == "y":
+                recipient_id = input("Enter recipient user ID (UUID): ").strip()
+                payload = {
+                    "type": "message",
+                    "content": msg,
+                    "recipient_id": recipient_id
+                }
+            else:
+                payload = {
+                    "type": "message",
+                    "content": msg
+                }
+            ws.send(json.dumps(payload))
     except KeyboardInterrupt:
         pass
     ws.close()

--- a/src/ws_server.rs
+++ b/src/ws_server.rs
@@ -1,15 +1,25 @@
-use actix::prelude::*;
+use uuid::Uuid;
+use actix::{prelude::*, Addr};
 use std::collections::{HashMap, HashSet};
 
 type SessionAddr = Addr<super::ws_session::ChatSession>;
 
 pub struct ChatServer {
+    pub sessions: HashMap<Uuid, SessionAddr>,
     rooms: HashMap<String, HashSet<SessionAddr>>,
+}
+pub struct RegisterSession {
+    pub user_id: Uuid,
+    pub addr: SessionAddr,
+}
+impl Message for RegisterSession {
+    type Result = ();
 }
 
 impl ChatServer {
     pub fn new() -> Self {
         Self {
+            sessions: HashMap::new(),
             rooms: HashMap::new(),
         }
     }
@@ -35,6 +45,13 @@ impl Handler<JoinRoom> for ChatServer {
     }
 }
 
+impl Handler<RegisterSession> for ChatServer {
+    type Result = ();
+    fn handle(&mut self, msg: RegisterSession, _: &mut Context<Self>) {
+        self.sessions.insert(msg.user_id, msg.addr);
+    }
+}
+
 pub struct BroadcastMessage {
     pub room_id: String,
     pub message: String,
@@ -51,6 +68,28 @@ impl Handler<BroadcastMessage> for ChatServer {
             for session in sessions {
                 session.do_send(super::ws_session::ServerMessage(msg.message.clone()));
             }
+        }
+    }
+}
+
+pub struct SendDirectMessage {
+    pub from: Uuid,
+    pub to: Uuid,
+    pub content: String,
+}
+impl Message for SendDirectMessage {
+    type Result = ();
+}
+
+impl Handler<SendDirectMessage> for ChatServer {
+    type Result = ();
+    fn handle(&mut self, msg: SendDirectMessage, _: &mut Context<Self>) {
+        if let Some(addr) = self.sessions.get(&msg.to) {
+            addr.do_send(super::ws_session::ServerMessage(format!("From {}: {}", msg.from, msg.content)));
+        }
+        
+        if let Some(addr) = self.sessions.get(&msg.from) {
+            addr.do_send(super::ws_session::ServerMessage(format!("To {}: {}", msg.to, msg.content)));
         }
     }
 }

--- a/src/ws_session.rs
+++ b/src/ws_session.rs
@@ -1,16 +1,20 @@
 use actix::{Actor, Addr, AsyncContext, Context, Handler, Message, StreamHandler};
 use actix_web_actors::ws;
 use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+use super::ws_server::RegisterSession;
 
 pub struct ChatSession {
     pub room_id: String,
+    pub user_id: Uuid,
     pub server_addr: Addr<super::ws_server::ChatServer>,
 }
 
 impl ChatSession {
-    pub fn new(room_id: String, server_addr: Addr<super::ws_server::ChatServer>) -> Self {
+    pub fn new(room_id: String, user_id: Uuid, server_addr: Addr<super::ws_server::ChatServer>) -> Self {
         Self {
             room_id,
+            user_id,
             server_addr,
         }
     }
@@ -22,6 +26,11 @@ impl Actor for ChatSession {
     fn started(&mut self, ctx: &mut Self::Context) {
         self.server_addr.do_send(super::ws_server::JoinRoom {
             room_id: self.room_id.clone(),
+            addr: ctx.address(),
+        });
+
+        self.server_addr.do_send(RegisterSession {
+            user_id: self.user_id,
             addr: ctx.address(),
         });
     }
@@ -43,14 +52,24 @@ impl Handler<ServerMessage> for ChatSession {
 impl StreamHandler<Result<ws::Message, ws::ProtocolError>> for ChatSession {
     fn handle(&mut self, msg: Result<ws::Message, ws::ProtocolError>, ctx: &mut Self::Context) {
         if let Ok(ws::Message::Text(text)) = msg {
-            // Expect JSON: { "type": "message", "content": "...", "room_id": "..." }
+            // Expect JSON: { "type": "message", "content": "...", "recipient_id": "..." }
             if let Ok(incoming) = serde_json::from_str::<IncomingMessage>(&text) {
                 if incoming.msg_type == "message" {
-                    self.server_addr
-                        .do_send(super::ws_server::BroadcastMessage {
-                            room_id: self.room_id.clone(),
-                            message: incoming.content,
-                        });
+                    if let Some(recipient_id) = incoming.recipient_id {
+                        if let Ok(recipient_uuid) = Uuid::parse_str(&recipient_id) {
+                            self.server_addr.do_send(super::ws_server::SendDirectMessage {
+                                from: self.user_id,
+                                to: recipient_uuid,
+                                content: incoming.content,
+                            });
+                        }
+                    } else {
+                        self.server_addr
+                            .do_send(super::ws_server::BroadcastMessage {
+                                room_id: self.room_id.clone(),
+                                message: incoming.content,
+                            });
+                    }
                 }
             }
         }
@@ -63,4 +82,5 @@ struct IncomingMessage {
     msg_type: String,
     content: String,
     room_id: Option<String>,
+    recipient_id: Option<String>,
 }


### PR DESCRIPTION
This PR updates the existing WebSocket route to implement one-to-one messaging. The websocket route now supports both room-based and direct (one-to-one) messaging.

For test, the python script has been modified to accomodate both room and private message.

Additional Note for Frontend:

- For private message, the `room_id` can be set to 0
- Add `recipient_id` which is the UUID of a user (recipient of the message) to the websocket message/payload for direct messaging